### PR TITLE
Raise \tripledash

### DIFF
--- a/unpacked/mhchem.js
+++ b/unpacked/mhchem.js
@@ -1709,9 +1709,12 @@ MathJax.Hub.Register.StartupHook("TeX Jax Ready", function () {
 
       //
       //  Needed for \bond for the ~ forms
-      //  Not perfectly aligned when zoomed in, but on 100%
+      //  The 2.56mu distance below is correct for the MathJax Main-Regular font. It raises a
+      //  \tiny hyphen-minus, U+002D, to be centered on the math axis.
+      //  Had we been raising the math minus, U+2212, the distance would been 2mu.
+      //  And of course MathJax allows other fonts, which will introduce small mis-alignments.
       //
-      tripledash: ["Macro", "\\vphantom{-}\\raise2mu{\\kern2mu\\tiny\\text{-}\\kern1mu\\text{-}\\kern1mu\\text{-}\\kern2mu}"]
+      tripledash: ["Macro", "\\vphantom{-}\\raise2.56mu{\\kern2mu\\tiny\\text{-}\\kern1mu\\text{-}\\kern1mu\\text{-}\\kern2mu}"]
     },
   }, null, true);
 


### PR DESCRIPTION
This PR makes a minor adjustment to the vertical alignment of `\tripledash`. 

In the MathJax_Main-Regular font, the glyph for hyphen-minus, U+002D, is slightly lower than the math minus, U+2212. This PR raises `\tripledash` by 2.56mu instead of 2mu as formerly done. The 2mu distance would have been correct for the math minus, but`\tripledash` uses the hyphen-minus.

To check the numbers, one can use [opentype.js](https://opentype.js.org/glyph-inspector.html) to inspect the font file downloaded from https://github.com/mathjax/MathJax/blob/master/fonts/HTML-CSS/TeX/otf/MathJax_Main-Regular.otf.
