### PR TITLE
Remove an unused .trim() method

### DIFF
--- a/unpacked/mhchem.js
+++ b/unpacked/mhchem.js
@@ -1190,7 +1190,6 @@ MathJax.Hub.Register.StartupHook("TeX Jax Ready", function () {
             }
             m[3] = m[4] || m[3];
             if (m[3]) {
-              m[3] = m[3].replace(/^\s|\s$/, m[3]);  // .trim();
               if (m[3] === "e"  ||  m[3].substr(0, 1) === "*") {
                 ret.push({ type_: 'cdot' });
               } else {


### PR DESCRIPTION
I watch the changes you made to fix #10 , and appreciate your prompt response. However, this line of code seems to have a problem. [#L1193](https://github.com/mhchem/MathJax-mhchem/blob/master/unpacked/mhchem.js#L1193)
```javascript
m[3] = m[3].replace(/^\s|\s$/, m[3]);  // .trim();
```
The code wouldn't work as intended for sure. A more correct `.trim()` should be:
```javascript
m[3] = m[3].replace(/^\s+|\s+$/g, '');
```
The replacement should be an empty string, rather than the original string, which was like a typo or something. Also notice the `g` flag; without that, only the first space would be replaced.

However, I tried some tests and found this bug didn't affect the displayed result, so I read the code more carefully. The corresponding part of regex should be at [#L236](https://github.com/mhchem/MathJax-mhchem/blob/master/unpacked/mhchem.js#L236) :
```javascript
/...([eE]|\s*(\*|x|\\times|\u00D7)\s*10\^).../
```
These are the fourth and fifth capturing groups, which are converted to `m[3]` and `m[4]`. The only occasion when `m[3]` contains spaces is `[eE]`
 mismatches, but then `m[4]` must match, and as we have
```javascript
m[3] = m[4] || m[3];
```
we can guarantee that `m[3]` will not contain any whitespace characters, so `.trim()` is unnecessary.